### PR TITLE
Improve Windows compatibility, do not call external shell commands (unzip, rm)

### DIFF
--- a/TRNG_ex1_nb.ipynb
+++ b/TRNG_ex1_nb.ipynb
@@ -12,7 +12,8 @@
     "from os import system\n",
     "from h5py import File as h5py_File\n",
     "import matplotlib.pyplot as plt\n",
-    "from notebook import notebookapp"
+    "from notebook import notebookapp\n",
+    "import zipfile"
    ]
   },
   {
@@ -65,15 +66,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a=system('unzip data/%s.zip -d . >> test.log'%s_data_file_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
    "outputs": [],
@@ -88,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdf5_file = '%s.h5'%s_data_file_name\n",
+    "hdf5_file = zipfile.ZipFile('data/%s.zip'%s_data_file_name).open('%s.h5'%s_data_file_name)\n",
     "data_file = h5py_File(hdf5_file,'r')\n",
     "v_ratio_period_sample_for_interact=np.array(data_file['parameters/v_ratio_period_sample'][0,:],dtype=np.uint32)\n",
     "v_jitter_for_interact=data_file['parameters/v_jitter'][0,:]\n",
@@ -96,7 +88,6 @@
     "v_raw_rng_image=data_file['images/rng_image'][0,:]\n",
     "m_raw_bits_from_one_RO=data_file['raw_bits/m_raw_bits_from_one_RO'][:]\n",
     "data_file.close()\n",
-    "system('rm -Rf %s'%hdf5_file)\n",
     "nb_test_per_corner=m_raw_bits_from_one_RO.shape[3]\n",
     "nb_bits=m_raw_bits_from_one_RO.shape[4]"
    ]
@@ -234,7 +225,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -248,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ voila>=0.1.8
 numpy
 matplotlib
 h5py
+zipfile


### PR DESCRIPTION
Issue: When running jupyter notebook locally on Windows, unzip and rm fail.
Solution: Avoid calling external unzip to extract the data archive, but instead access the contents directly from python using zipfile.